### PR TITLE
Fix CMake Ninja build helper without parallel

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -289,6 +289,12 @@ class CMake(object):
                 # Parallel for building projects in the solution
                 args.append("/m:%i" % cpu_count(output=self._conanfile.output))
 
+        if self.generator and not self.parallel:
+            if "Ninja" in self.generator:
+                if "--" not in args:
+                    args.append("--")
+                args.append("-j1")
+
         if self.generator and self.msbuild_verbosity:
             if "Visual Studio" in self.generator and \
                     compiler_version and Version(compiler_version) >= "10":


### PR DESCRIPTION
Changelog: (Fix): Fix CMake build helper when parallel is false and using the Ninja generator

- [ X] Refer to the issue that supports this Pull Request.
No linked issue
- [ X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
When using the cmake build helper with the ninja generator, when setting `` to false, it will use the default ninja behaviour which is to do  builds. This commit enforce the number of jobs to one in that case.
- [ X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X ] I've followed the PEP8 style guides for Python code.
- [] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
